### PR TITLE
fix(helpers): Correctly default platform to Linux

### DIFF
--- a/metasip/helpers/header_directory.py
+++ b/metasip/helpers/header_directory.py
@@ -15,7 +15,7 @@ def get_platform_name():
     if sys.platform == 'win32':
         return 'Windows'
 
-    platform_name = 'Linux'
+    return 'Linux'
 
 
 def get_supported_platforms():


### PR DESCRIPTION
Correct a crash that could occur on Linux when Metasip attempted to look up the default platform name, and got `None` instead of the string `"Linux"`.
